### PR TITLE
fix(context): wrap client schemas to avoid iterating over 'nil'

### DIFF
--- a/lua/schema-companion/context.lua
+++ b/lua/schema-companion/context.lua
@@ -103,7 +103,9 @@ function M.schema(bufnr, data)
 
     local override = {}
 
-    for u, b in pairs(client.settings.yaml.schemas) do
+    local schemas = client.settings.yaml.schemas or {}
+
+    for u, b in pairs(schemas) do
       if b == bufuri then
         override[u] = false
         log.debug("removed override: file=%s schema=%s", b, u)


### PR DESCRIPTION
Schema forwarding to the LSP fails, because iterating over the client.settings.yaml.schemas fails if no client schemas are set.

After some testing, cause schema detection wasn't working, I found that
execution fails after the section that avoids overriding existing
associations.

The problem is that Lua fails when iterating over nil.
Iterating over an empty table is fine, so I replace nil with an empty
table.

See https://onecompiler.com/lua/43h8rkk43 for more code examples.
