### PR TITLE
docs: update setup example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ require("schema-companion").setup({
   enable_telescope = false,
   matchers = {},
   schemas = {},
-}
-
+})
 ```
 
 ### Language Server Configuration


### PR DESCRIPTION
Updates the example in the README with the missing ending parenthesis.