### PR TITLE
refactor: load using updated name for telescope extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,13 @@ Adding custom matchers are as easy as defining a function that detects and handl
 You can map the `telescope` picker to any keybinding of your choice.
 
 ```lua
-require("telescope").extensions.yaml_schema.select_schema()
+require("telescope").extensions.schema_companion.select_schema()
 ```
 
 If there are multiple matches for the buffer, you can select the schema manually from the ones that matches.
 
 ```lua
-require("telescope").extensions.yaml_schema.select_from_matching_schemas()
+require("telescope").extensions.schema_companion.select_from_matching_schemas()
 ```
 
 ### Current Schema

--- a/lua/schema-companion/init.lua
+++ b/lua/schema-companion/init.lua
@@ -9,7 +9,7 @@ function M.setup(config)
 
   if c.enable_telescope then
     xpcall(function()
-      return require("telescope").load_extension("yaml_schema")
+      return require("telescope").load_extension("schema_companion")
     end, debug.traceback)
   end
 


### PR DESCRIPTION
I noticed that the Telescope extension was renamed, so this is to reflect that change.