### PR TITLE
fix/safe index possibly undefined field

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,7 @@
+{
+  "diagnostics": {
+    "globals": [
+      "vim"
+    ]
+  }
+}

--- a/lua/schema-companion/context.lua
+++ b/lua/schema-companion/context.lua
@@ -103,7 +103,10 @@ function M.schema(bufnr, data)
 
     local override = {}
 
-    local schemas = client.settings.yaml.schemas or {}
+    local schemas = {}
+    if client.settings and client.settings.yaml and client.settings.yaml.schemas then
+      schemas = client.settings.yaml.schemas
+    end
 
     for u, b in pairs(schemas) do
       if b == bufuri then


### PR DESCRIPTION
Fixes #12 as a safer way to index down into `client.settings.yaml.schemas` to avoid a `nil` error. That can happen when the user uses a config like this:

```lua
  {
    "yamlls",
    lsp = require("schema-companion").setup_client({ }),
  },
```