### PR TITLE
fix: notify nvim-lspconfig that we are using dynamic registration

### DIFF
--- a/lua/schema-companion/init.lua
+++ b/lua/schema-companion/init.lua
@@ -34,12 +34,23 @@ function M.setup_client(config)
     end
   end
 
+  -- create capabilities while integrating user-provided capabilities
+  local capabilities = vim.tbl_deep_extend("force", vim.lsp.protocol.make_client_capabilities(), config.capabilities or {}, {
+    workspace = {
+      didChangeConfiguration = {
+        dynamicRegistration = true,
+      },
+    },
+  })
+
   return vim.tbl_deep_extend(
     "force",
     {},
     config,
     ---@type vim.lsp.ClientConfig
     {
+      capabilities = capabilities,
+
       on_attach = add_hook_after(config.on_attach, function(client, bufnr)
         require("schema-companion.context").setup(bufnr, client)
       end),


### PR DESCRIPTION
This fixes errors like these from appearing in `:LspLog`:

```
[WARN][2025-06-09 05:23:13] ...m/lsp/client.lua:874	"The language server yamlls triggers a registerCapability handler for workspace/didChangeConfiguration despite dynamicRegistration set to false. Report upstream, this warning is harmless"
```