### PR TITLE
refactor(setup): simpler adapter setup (callable adapters)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Plugin has to be configured once, and the language servers can be added by exten
 **If you do not configure the language server with the adapter, the plugin will not work for the given language server.**
 
 > [!WARNING]
-> Legacy `schema-companion.setup_client()` and `adapter.setup()` are deprecated and will emit warnings.
-> Call adapters directly; they are now callable and return the finalized LSP configuration. 
+> Legacy `schema-companion.setup_client()`, `adapter.setup()` and `source.setup()` are deprecated and will emit warnings.
+> Call adapters and sources directly; they are now callable and return the finalized LSP or source configuration. 
 
 > [!IMPORTANT]
 > THIS PLUGIN IS A LITTLE BIT MORE INVOLVED THAN AVERAGE PLUGIN, PLEASE FOLLOW THE INSTRUCTIONS CAREFULLY.
@@ -64,9 +64,9 @@ The plugin has an adapter based system, where you can define different configura
 local sc = require("schema-companion")
 return sc.adapters.yamlls({
   sources = {
-    sc.sources.matchers.kubernetes.setup({ version = "master" }),
-    sc.sources.lsp.setup(),
-    sc.sources.schemas.setup({
+    sc.sources.matchers.kubernetes({ version = "master" }),
+    sc.sources.lsp(),
+    sc.sources.schemas({
       {
         name = "Kubernetes master",
         uri = "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/all.json",
@@ -85,7 +85,7 @@ return sc.adapters.yamlls({
 local sc = require("schema-companion")
 return sc.adapters.helmls({
   sources = {
-    sc.sources.matchers.kubernetes.setup({ version = "master" }),
+    sc.sources.matchers.kubernetes({ version = "master" }),
   },
   --- your language server configuration (settings, init_options, capabilities...)
   settings = {},
@@ -99,8 +99,8 @@ return sc.adapters.helmls({
 local sc = require("schema-companion")
 return sc.adapters.jsonls({
   sources = {
-    sc.sources.lsp.setup(),
-    sc.sources.none.setup(),
+    sc.sources.lsp(),
+    sc.sources.none(),
   },
   --- your language server configuration (settings, init_options, capabilities...)
   settings = {},
@@ -114,8 +114,8 @@ return sc.adapters.jsonls({
 local sc = require("schema-companion")
 return sc.adapters.taplo({
   sources = {
-    sc.sources.lsp.setup(),
-    sc.sources.none.setup(),
+    sc.sources.lsp(),
+    sc.sources.none(),
   },
   --- your language server configuration (settings, init_options, capabilities...)
   settings = {},
@@ -130,9 +130,9 @@ return sc.adapters.taplo({
 local sc = require("schema-companion")
 vim.lsp.comfig("yamlls", sc.adapters.yamlls({
   sources = {
-    sc.sources.matchers.kubernetes.setup({ version = "master" }),
-    sc.sources.lsp.setup(),
-    sc.sources.schemas.setup({
+    sc.sources.matchers.kubernetes({ version = "master" }),
+    sc.sources.lsp(),
+    sc.sources.schemas({
       {
         name = "Kubernetes master",
         uri = "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/all.json",
@@ -149,7 +149,7 @@ vim.lsp.comfig("yamlls", sc.adapters.yamlls({
 local sc = require("schema-companion")
 vim.lsp.config("helm_ls", sc.adapters.helmls({
   sources = {
-    sc.sources.matchers.kubernetes.setup({ version = "master" }),
+    sc.sources.matchers.kubernetes({ version = "master" }),
   },
   --- your language server configuration (settings, init_options, capabilities...)
 }))
@@ -161,8 +161,8 @@ vim.lsp.config("helm_ls", sc.adapters.helmls({
 local sc = require("schema-companion")
 vim.lsp.config("jsonls", sc.adapters.jsonls({
   sources = {
-    sc.sources.lsp.setup(),
-    sc.sources.none.setup(),
+    sc.sources.lsp(),
+    sc.sources.none(),
   },
   --- your language server configuration (settings, init_options, capabilities...)
 }))
@@ -174,8 +174,8 @@ vim.lsp.config("jsonls", sc.adapters.jsonls({
 local sc = require("schema-companion")
 vim.lsp.config("taplo", sc.adapters.taplo({
   sources = {
-    sc.sources.lsp.setup(),
-    sc.sources.none.setup(),
+    sc.sources.lsp(),
+    sc.sources.none(),
   },
   --- your language server configuration (settings, init_options, capabilities...)
 }))
@@ -255,7 +255,7 @@ To enable language server implicitly using schemas provided by the language serv
 ```lua
 sources = {
   -- your sources for the language server
-  require("schema-companion").sources.lsp.setup()
+  require("schema-companion").sources.lsp()
 },
 ```
 
@@ -266,7 +266,7 @@ You can provide static set of schemas where you do want to only manual selection
 ```lua
 sources = {
   -- your sources for the language server
-  require("schema-companion").sources.schemas.setup({
+  require("schema-companion").sources.schemas({
     {
       name = "Kubernetes v1.29",
       uri = "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.29.7-standalone-strict/all.json",
@@ -290,7 +290,7 @@ Available matchers for the plugin is as follows.
 ```lua
 sources = {
   -- your sources for the language server
-  require("schema-companion").sources.matchers.kubernetes.setup({
+  require("schema-companion").sources.matchers.kubernetes({
     version = "master"
   })
 },
@@ -303,7 +303,7 @@ None source provides a way to reset the current schema to `none`.
 ```lua
 sources = {
   -- your sources for the language server
-  require("schema-companion").sources.none.setup()
+  require("schema-companion").sources.none()
 },
 ```
 

--- a/lua/schema-companion/adapters/helmls.lua
+++ b/lua/schema-companion/adapters/helmls.lua
@@ -92,6 +92,6 @@ function M:match_schema_from_lsp(bufnr)
   return schemas
 end
 
-M.setup = require("schema-companion.adapters.metatable").new(M)
+M = require("schema-companion.adapters.metatable").new(M)
 
 return M

--- a/lua/schema-companion/adapters/jsonls.lua
+++ b/lua/schema-companion/adapters/jsonls.lua
@@ -97,6 +97,6 @@ function M:match_schema_from_lsp(bufnr)
   return schemas
 end
 
-M.setup = require("schema-companion.adapters.metatable").new(M)
+M = require("schema-companion.adapters.metatable").new(M)
 
 return M

--- a/lua/schema-companion/adapters/metatable.lua
+++ b/lua/schema-companion/adapters/metatable.lua
@@ -37,7 +37,7 @@ local function initialize_sources(self, config)
   config = config or {}
   self.ctx = self.ctx or {}
   self.ctx.sources = utils.evaluate_property(config.sources) or {
-    require("schema-companion.sources").lsp.setup(),
+    require("schema-companion.sources").lsp(),
   }
   log.debug(
     "adapter sources loaded: adapter_name=%s sources=%s",

--- a/lua/schema-companion/adapters/taplo.lua
+++ b/lua/schema-companion/adapters/taplo.lua
@@ -86,6 +86,6 @@ function M:match_schema_from_lsp(bufnr)
   return schemas
 end
 
-M.setup = require("schema-companion.adapters.metatable").new(M)
+M = require("schema-companion.adapters.metatable").new(M)
 
 return M

--- a/lua/schema-companion/adapters/yamlls.lua
+++ b/lua/schema-companion/adapters/yamlls.lua
@@ -95,6 +95,6 @@ function M:match_schema_from_lsp(bufnr)
   return schemas
 end
 
-M.setup = require("schema-companion.adapters.metatable").new(M)
+M = require("schema-companion.adapters.metatable").new(M)
 
 return M

--- a/lua/schema-companion/deprecated.lua
+++ b/lua/schema-companion/deprecated.lua
@@ -3,6 +3,7 @@
 local M = {
   adapter_setup = false,
   setup_client = false,
+  source_setup = false,
 }
 
 return M

--- a/lua/schema-companion/deprecated.lua
+++ b/lua/schema-companion/deprecated.lua
@@ -1,0 +1,8 @@
+-- Internal deprecation usage tracking.
+-- Flags are toggled when legacy APIs are invoked so health checks can warn.
+local M = {
+  adapter_setup = false,
+  setup_client = false,
+}
+
+return M

--- a/lua/schema-companion/health.lua
+++ b/lua/schema-companion/health.lua
@@ -17,6 +17,12 @@ function M.check()
   else
     vim.health.ok("Using new direct adapter call API")
   end
+
+  if deprecated.source_setup then
+    vim.health.warn("Deprecated API used: source.setup(). Migrate to direct source call: require('schema-companion').source.none()")
+  else
+    vim.health.ok("Using new direct source call API")
+  end
 end
 
 return M

--- a/lua/schema-companion/health.lua
+++ b/lua/schema-companion/health.lua
@@ -1,10 +1,22 @@
--- local health = vim.health
-
 local M = {}
 
 function M.check()
-  --- TODO: refactor this completely
-  error("NOT IMPLEMENTED, HAVE TO BE REFACTORED")
+  local deprecated = require("schema-companion.deprecated")
+
+  if deprecated.adapter_setup or deprecated.setup_client then
+    local list = {}
+    if deprecated.adapter_setup then
+      table.insert(list, "adapter.setup()")
+    end
+    if deprecated.setup_client then
+      table.insert(list, "setup_client()")
+    end
+    vim.health.warn(
+      "Deprecated API used: " .. table.concat(list, ", ") .. ". Migrate to direct adapter call: require('schema-companion').adapters.yamlls{ sources = {...}, settings = {...} }"
+    )
+  else
+    vim.health.ok("Using new direct adapter call API")
+  end
 end
 
 return M

--- a/lua/schema-companion/init.lua
+++ b/lua/schema-companion/init.lua
@@ -23,8 +23,9 @@ end
 ---@param config? vim.lsp.ClientConfig --- User configuration for the language server.
 ---@returns vim.lsp.ClientConfig
 function M.setup_client(adapter, config)
+  require("schema-companion.log").warn("schema-companion.setup_client is deprecated; call the adapter directly: adapter_name=%s", adapter.name)
+  require("schema-companion.deprecated").setup_client = true
   config = config or {}
-
   return adapter:on_setup_client(config)
 end
 

--- a/lua/schema-companion/meta.lua
+++ b/lua/schema-companion/meta.lua
@@ -28,7 +28,7 @@ error("Can not source metafile.")
 ---@field ctx schema_companion.AdapterCtx
 ---@field name string
 ---@field config? table
----@field setup schema_companion.AdapterSetupFn
+---@field setup schema_companion.AdapterSetupFn @deprecated Use calling the adapter directly
 ---@field health? schema_companion.HealthFn
 ---@field client vim.lsp.Client
 ---@field set_client fun(self: schema_companion.Adapter, client: vim.lsp.Client): vim.lsp.Client
@@ -38,6 +38,7 @@ error("Can not source metafile.")
 ---@field on_setup_client schema_companion.AdapterOnSetupClientFn
 ---@field on_update_schemas schema_companion.AdapterOnUpdateSchemaFn
 ---@field get_sources schema_companion.AdapterGetSourcesFn
+---@field __call schema_companion.AdapterCallFn
 
 ---@class schema_companion.AdapterConfig
 ---@field sources? schema_companion.Source[] | fun(): schema_companion.Source[]
@@ -45,6 +46,7 @@ error("Can not source metafile.")
 ---@class schema_companion.AdapterCtx
 ---@field sources schema_companion.Source[]
 
+---@alias schema_companion.AdapterCallFn fun(self: schema_companion.Adapter, config?: vim.lsp.ClientConfig): vim.lsp.ClientConfig
 ---@alias schema_companion.AdapterSetupFn fun(config: schema_companion.AdapterConfig): schema_companion.Adapter
 ---@alias schema_companion.AdapterOnSetupClientFn fun(self: schema_companion.Adapter, config: vim.lsp.ClientConfig): vim.lsp.ClientConfig
 ---@alias schema_companion.AdapterOnUpdateSchemaFn fun(self: schema_companion.Adapter, bufnr: number, schemas: schema_companion.Schema[]): nil

--- a/lua/schema-companion/meta.lua
+++ b/lua/schema-companion/meta.lua
@@ -15,14 +15,16 @@ error("Can not source metafile.")
 ---@class schema_companion.Source: table
 ---@field name string
 ---@field config? table
----@field setup schema_companion.SourceSetupFn
+---@field setup schema_companion.SourceSetupFn @deprecated Use calling the source directly
 ---@field health? schema_companion.HealthFn
 ---@field match? schema_companion.SourceMatchFn
 ---@field get_schemas? schema_companion.SourceGetSchemasFn
+---@field __call schema_companion.SourceCallFn
 
 ---@alias schema_companion.SourceSetupFn fun(table?): schema_companion.Source
 ---@alias schema_companion.SourceMatchFn fun(self: schema_companion.Source, ctx: schema_companion.Context, bufnr?: number): schema_companion.Schema[]
 ---@alias schema_companion.SourceGetSchemasFn fun(self: schema_companion.Source, ctx: schema_companion.Context, bufnr?: number): schema_companion.Schema[]
+---@alias schema_companion.SourceCallFn fun(self: schema_companion.Source, config?: table): schema_companion.Source
 
 ---@class schema_companion.Adapter: table
 ---@field ctx schema_companion.AdapterCtx

--- a/lua/schema-companion/sources/lsp.lua
+++ b/lua/schema-companion/sources/lsp.lua
@@ -1,13 +1,10 @@
 ---@class schema_companion.Source
 local M = {}
 
+local wrap = require("schema-companion.sources.metatable")
 local log = require("schema-companion.log")
 
 M.name = "LSP"
-
-function M.setup()
-  return M
-end
 
 ---@param ctx schema_companion.Context
 ---@param schemas schema_companion.Schema[]
@@ -37,4 +34,4 @@ function M:match(ctx, bufnr)
   return enrich_schemas(ctx, matches)
 end
 
-return M
+return wrap(M)

--- a/lua/schema-companion/sources/matchers/cloud-init.lua
+++ b/lua/schema-companion/sources/matchers/cloud-init.lua
@@ -1,18 +1,16 @@
----@class schema_companion.Matcher
+---@class schema_companion.Source
 local M = {}
+
+local wrap = require("schema-companion.sources.metatable")
 
 M.name = "Cloud-Init"
 
 M.config = {}
 
----
----@param config table
----@return schema_companion.Matcher
-function M.setup(config)
-  setmetatable(M, {})
-  M.config = vim.tbl_deep_extend("force", {}, M.config, config)
-
-  return M
+local function apply(self, config)
+  if config then
+    self.config = vim.tbl_deep_extend("force", {}, self.config, config)
+  end
 end
 
 function M:match(_, bufnr)
@@ -27,4 +25,4 @@ function M:match(_, bufnr)
   end
 end
 
-return M
+return wrap(M, apply)

--- a/lua/schema-companion/sources/matchers/kubernetes.lua
+++ b/lua/schema-companion/sources/matchers/kubernetes.lua
@@ -1,6 +1,7 @@
 ---@class schema_companion.Source
 local M = {}
 
+local wrap = require("schema-companion.sources.metatable")
 local log = require("schema-companion.log")
 local utils = require("schema-companion.utils")
 
@@ -10,14 +11,10 @@ M.config = {
   version = "master",
 }
 
----
----@param config { version: string }
----@return schema_companion.Source
-function M.setup(config)
-  setmetatable(M, {})
-  M.config = vim.tbl_deep_extend("force", {}, M.config, config)
-
-  return M
+local function apply(self, config)
+  if config then
+    self.config = vim.tbl_deep_extend("force", {}, self.config, config)
+  end
 end
 
 function M.set_version(version)
@@ -157,4 +154,4 @@ function M:match(_, bufnr)
   return schemas
 end
 
-return M
+return wrap(M, apply)

--- a/lua/schema-companion/sources/metatable.lua
+++ b/lua/schema-companion/sources/metatable.lua
@@ -1,0 +1,27 @@
+local log = require("schema-companion.log")
+local deprecated = require("schema-companion.deprecated")
+
+--- Wrap a source table to be callable, providing legacy setup() with deprecation warning.
+--- apply(self, config) is invoked when calling the source.
+---@param source schema_companion.Source
+---@param apply fun(self: schema_companion.Source, config?: table)|nil
+---@return schema_companion.Source
+return function(source, apply)
+  apply = apply or function() end
+
+  local mt = {}
+  mt.__call = function(self, config)
+    apply(self, config)
+    return self
+  end
+
+  setmetatable(source, mt)
+
+  source.setup = function(config)
+    log.warn("schema-companion source.setup() is deprecated; call source directly instead: source_name=%s", source.name)
+    deprecated.source_setup = true
+    return mt.__call(source, config)
+  end
+
+  return source
+end

--- a/lua/schema-companion/sources/none.lua
+++ b/lua/schema-companion/sources/none.lua
@@ -1,6 +1,8 @@
 ---@class schema_companion.Source
 local M = {}
 
+local wrap = require("schema-companion.sources.metatable")
+
 M.name = "None"
 
 M.config = {}
@@ -15,16 +17,11 @@ local function enrich_schemas(schemas)
       schema.source = M.name
     end
   end
-
   return schemas
-end
-
-function M.setup()
-  return M
 end
 
 function M:get_schemas()
   return enrich_schemas(require("schema-companion.schema").get_default_schemas())
 end
 
-return M
+return wrap(M)

--- a/lua/schema-companion/sources/schemas.lua
+++ b/lua/schema-companion/sources/schemas.lua
@@ -1,6 +1,8 @@
 ---@class schema_companion.Source
 local M = {}
 
+local wrap = require("schema-companion.sources.metatable")
+
 M.name = "Schemas"
 
 M.config = {}
@@ -19,18 +21,14 @@ local function enrich_schemas(schemas)
   return schemas
 end
 
----
----@param schemas schema_companion.Schema[]
----@return schema_companion.Source
-function M.setup(schemas)
-  setmetatable(M, {})
-  M.config = enrich_schemas(schemas)
-
-  return M
+local function apply(self, schemas)
+  if schemas then
+    self.config = enrich_schemas(schemas)
+  end
 end
 
 function M:get_schemas()
   return self.config
 end
 
-return M
+return wrap(M, apply)


### PR DESCRIPTION
Hi 👋🏼 

This PR is a proposal for setup simplification (API and doc).

Basically change this: 
```lua
return require("schema-companion").setup_client(
  require("schema-companion").adapters.yamlls.setup({
    sources = {
      -- your sources for the language server
      require("schema-companion").sources.matchers.kubernetes.setup({ version = "master" }),
      require("schema-companion").sources.lsp.setup(),
      require("schema-companion").sources.schemas.setup({
        {
          name = "Kubernetes master",
          uri = "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/all.json",
        },
      }),
    },
  }),
  {
    --- your yaml language server configuration
    settings = {...},
    ...
  }
)
```
into this
```lua
local sc = require("schema-companion")
return sc.adapters.yamlls({
  sources = {
    -- your sources for the language server
    sc.sources.matchers.kubernetes({ version = "master" }),
    sc.sources.lsp(),
    sc.sources.schema({
      {
        name = "Kubernetes master",
        uri = "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/all.json",
      },
    }),
  },
  --- your yaml language server configuration
  settings = {...},
  ...
})
```

This PR:
- makes adapters callable (but keep the legacy API and warn for deprecation)
- makes sources callable (but keep the legacy API and warn for deprecation)
- simplify some README examples
- adds `vim.lsp.config()` documentation (alternative to `after/lsp` overlays)
- makes use of [GFM Alerts](https://docs.github.com/fr/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) in the README
- fixes some typos in the README

I think it makes the setup less "overwhelming".
If you are interested, I can refactor and/or split this PR as you want (I hesitated to submit a single PR but I did this in a single pass

> [!NOTE]
> Most of the complexity is in the metatable to maintain backward compatibility and properly warn with `checkhealth` support.
> Without backward compatibility and checkhealth sypport, we just have to return function from modules, no metatable require for sources and not `health` and `deprecated` modules. 